### PR TITLE
네트워킹 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-aspect-ratio": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-dropdown-menu": "^2.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
@@ -973,6 +974,40 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
     "node_modules/@hookform/resolvers": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-4.1.3.tgz",
@@ -1176,6 +1211,28 @@
         "@radix-ui/react-id": "1.1.0",
         "@radix-ui/react-primitive": "2.0.2",
         "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
+      "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1409,6 +1466,34 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.6.tgz",
+      "integrity": "sha512-no3X7V5fD487wab/ZYSHXq3H37u4NVeLDKI/Ks724X/eEFSSEFYZxWgsIlr1UBeEyDaM29HM5x9p1Nv8DuTYPA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-menu": "2.1.6",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
@@ -1474,6 +1559,76 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.6.tgz",
+      "integrity": "sha512-tBBb5CXDJW3t2mo9WlO7r6GTmWV0F0uzHZVFmlRmYpiSK1CDU5IKojP1pm7oknpBOrFZx/YgBRW9oorPO2S/Lg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.2",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-roving-focus": "1.1.2",
+        "@radix-ui/react-slot": "1.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
+      "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1773,6 +1928,23 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
+      "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.0.tgz",
@@ -1790,6 +1962,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.6.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-aspect-ratio": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-dropdown-menu": "^2.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",

--- a/src/components/NetworkingListPage/AddModal.tsx
+++ b/src/components/NetworkingListPage/AddModal.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+interface AddModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const AddModal: React.FC<AddModalProps> = ({ isOpen, onClose }): React.JSX.Element => {
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={onClose}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/70 z-50" />
+        <Dialog.Content className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gray-800 p-6 rounded-lg shadow-lg text-white w-80 text-center z-50">
+          <Dialog.Title className="text-lg font-semibold">추가되었습니다.</Dialog.Title>
+          <p className="text-gray-400 mt-2">성공적으로 명함이 추가되었습니다.</p>
+          <button onClick={onClose} className="mt-4 bg-green-500 px-4 py-2 rounded-lg text-white">
+            확인
+          </button>
+          <Dialog.Close asChild>
+            <button className="absolute top-3 right-3 text-gray-400 hover:text-white">
+              <X size={20} />
+            </button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default AddModal;

--- a/src/components/NetworkingListPage/BusinessCardConsentSheet.tsx
+++ b/src/components/NetworkingListPage/BusinessCardConsentSheet.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+} from '@components/ui/drawer';
+
+interface BusinessCardConsentSheetProps {
+  open: boolean;
+  onAgree: () => void;
+  onClose: () => void; // onClose 추가
+}
+
+const BusinessCardConsentSheet: React.FC<BusinessCardConsentSheetProps> = ({
+  open,
+  onAgree,
+}): React.JSX.Element => {
+  const navigate = useNavigate();
+
+  return (
+    <Drawer open={open} shouldScaleBackground={false} handleOnly={true}>
+      <DrawerPortal>
+        {/* 배경 클릭 비활성화 */}
+        <DrawerOverlay className="inset-0 bg-black/70" />
+
+        {/* 서랍을 아예 움직이지 못하도록 고정 */}
+        <DrawerContent
+          hideIndicator
+          className="bottom-0 left-0 w-full bg-gray-900 text-white rounded-t-2xl p-6 z-50 
+          "
+        >
+          <DrawerHeader>
+            <DrawerTitle className="text-white text-lg font-semibold text-center mb-4">
+              온라인 명함 리스트에 명함을 공개할까요?
+            </DrawerTitle>
+          </DrawerHeader>
+          <div className="px-4 pointer-events-auto">
+            {' '}
+            {/* 버튼은 클릭 가능하도록 */}
+            <button
+              onClick={onAgree}
+              className="w-full bg-green-600 py-3 rounded-lg mb-3 cursor-pointer text-white font-semibold"
+            >
+              공개할래요
+            </button>
+            <button
+              className="w-full text-gray-400 text-sm cursor-pointer"
+              onClick={() => navigate('/')}
+            >
+              돌아갈래요
+            </button>
+          </div>
+          <DrawerFooter>
+            <p className="text-xs text-gray-500 text-center">
+              공개하지 않으면 네트워킹 기능을 이용할 수 없어요.
+            </p>
+          </DrawerFooter>
+        </DrawerContent>
+      </DrawerPortal>
+    </Drawer>
+  );
+};
+
+export default BusinessCardConsentSheet;

--- a/src/components/NetworkingListPage/Card.tsx
+++ b/src/components/NetworkingListPage/Card.tsx
@@ -1,0 +1,119 @@
+import { useRef, MouseEvent, TouchEvent } from 'react';
+import { Button } from '@components/ui/button';
+
+interface CardProps {
+  isGlossy: boolean;
+  isMobile: boolean;
+  isChat: boolean;
+}
+
+const Card = ({ isGlossy, isMobile, isChat }: CardProps) => {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  const handleMove = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
+    const card = e.currentTarget as HTMLDivElement;
+    const rect = card.getBoundingClientRect();
+    const clientX = isMobile
+      ? (e as TouchEvent<HTMLDivElement>).touches[0].clientX
+      : (e as MouseEvent<HTMLDivElement>).clientX;
+    const clientY = isMobile
+      ? (e as TouchEvent<HTMLDivElement>).touches[0].clientY
+      : (e as MouseEvent<HTMLDivElement>).clientY;
+
+    const mouseX = clientX - rect.left;
+    const mouseY = clientY - rect.top;
+    const xAxis = (clientX - rect.left - rect.width / 2) / 20;
+    const yAxis = (clientY - rect.top - rect.height / 2) / 20;
+
+    // 카드 각도 조절
+    card.style.transform = `rotateY(${-xAxis}deg) rotateX(${yAxis}deg)`;
+
+    // 유광 효과 업데이트
+    const glossyOverlay = card.querySelector('.overlay.glossy') as HTMLElement;
+    if (glossyOverlay) {
+      glossyOverlay.style.background = `radial-gradient(circle at ${mouseX}px ${mouseY}px, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0.03) 70%, transparent 100%)`;
+      glossyOverlay.style.opacity = '1';
+    }
+  };
+
+  const handleEnter = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
+    const card = e.currentTarget as HTMLDivElement;
+    const glossyOverlay = card.querySelector('.overlay.glossy') as HTMLElement;
+
+    if (glossyOverlay) {
+      glossyOverlay.style.opacity = '1';
+    }
+  };
+
+  const handleLeave = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
+    const card = e.currentTarget as HTMLDivElement;
+
+    // 카드 초기화
+    card.style.transform = 'rotateY(0deg) rotateX(0deg)';
+
+    // 유광 효과 초기화
+    const glossyOverlay = card.querySelector('.overlay.glossy') as HTMLElement;
+    if (glossyOverlay) {
+      glossyOverlay.style.opacity = '0';
+      glossyOverlay.style.background = 'none';
+    }
+  };
+
+  return (
+    <>
+      <div className="flex justify-center items-center  perspective-[1500px]">
+        <div
+          ref={cardRef}
+          className="w-[80mm] h-[128mm] bg-gradient-to-br from-blue-500 to-blue-700 rounded-3xl shadow-lg transform-style-preserve-3d transition-transform duration-300 ease-out relative flex flex-col justify-center items-center gap-2 will-change-transform"
+          onMouseEnter={!isMobile ? handleEnter : undefined}
+          onMouseMove={!isMobile ? handleMove : undefined}
+          onMouseLeave={!isMobile ? handleLeave : undefined}
+          onTouchStart={isMobile ? handleEnter : undefined}
+          onTouchMove={isMobile ? handleMove : undefined}
+          onTouchEnd={isMobile ? handleLeave : undefined}
+        >
+          {isGlossy && (
+            <div className="overlay glossy absolute top-0 left-0 w-full h-full rounded-inherit pointer-events-none transition-opacity duration-300"></div>
+          )}
+
+          <div className="flex flex-row justify-center items-center gap-4">
+            <Button
+              className="w-9 h-9 bg-white text-blue-500 rounded-full shadow-lg flex justify-center items-center"
+              disabled={!isChat}
+            >
+              💬
+            </Button>
+            <Button className="w-9 h-9 bg-white text-blue-500 rounded-full shadow-lg flex justify-center items-center">
+              📚
+            </Button>
+          </div>
+
+          <div className="text-white text-center flex flex-col justify-center items-center">
+            <h1>이종혁</h1>
+            <p className="font-bold text-2xl">프론트엔드 개발자</p>
+            <p>E-mail: jonghyeok@example.com</p>
+            <p>Phone: +123-456-7890</p>
+
+            <div className="flex items-center">
+              <span>github.com/leejh5314</span>
+            </div>
+
+            <div className="flex justify-center">
+              <span className="bg-white/20 text-white font-bold text-xs py-1 px-2 rounded-full mx-2">
+                Next.js
+              </span>
+              <span className="bg-white/20 text-white font-bold text-xs py-1 px-2 rounded-full mx-2">
+                TypeScript
+              </span>
+              <span className="bg-white/20 text-white font-bold text-xs py-1 px-2 rounded-full mx-2">
+                React
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Card;

--- a/src/components/NetworkingListPage/FullScreenPopup.tsx
+++ b/src/components/NetworkingListPage/FullScreenPopup.tsx
@@ -1,0 +1,52 @@
+// FullScreenPopup.tsx
+import React from 'react';
+import { X } from 'lucide-react';
+import { Dialog, DialogContent } from '@components/ui/dialog';
+
+interface FullScreenPopupProps {
+  open: boolean;
+  onClose: () => void; // X 버튼용: 단순 닫기
+  onDontShowAgain: () => void; // "다시 보지 않기"- 닫고 로컬스토리지 저장
+}
+const FullScreenPopup: React.FC<FullScreenPopupProps> = ({
+  open,
+  onClose,
+  onDontShowAgain,
+}): React.JSX.Element => {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent
+        hideCloseButton
+        className="
+          !fixed !inset-0 !w-full !h-full !max-w-none !max-h-none 
+          !translate-x-0 !translate-y-0 !rounded-none !border-none !shadow-none
+          p-0 flex flex-col
+        "
+      >
+        {/* X 버튼: 단순 닫기 (팝업이 다음에 다시 뜰 수 있음) */}
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-white opacity-80 hover:opacity-100"
+        >
+          <X size={24} />
+        </button>
+
+        {/* 전체 화면 영역 중앙 정렬 */}
+        <div className="flex-1 flex flex-col justify-center items-center bg-gray-900 text-white">
+          <div className="w-full max-w-md bg-gray-800 p-6 rounded-lg text-center">
+            <p className="text-lg font-semibold mb-4">
+              네트워킹 리스트 페이지는 이런 페이지입니다.
+            </p>
+            <p className="text-gray-400 mb-6">안내 문구</p>
+            {/* "다시 보지 않기" 버튼: 닫고 로컬스토리지에 기록 */}
+            <button className="w-full bg-gray-700 py-3 rounded-lg" onClick={onDontShowAgain}>
+              다시 보지 않기
+            </button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FullScreenPopup;

--- a/src/components/NetworkingListPage/MockApi.ts
+++ b/src/components/NetworkingListPage/MockApi.ts
@@ -1,0 +1,33 @@
+export const mockGetUserData = async () => {
+  return new Promise<{ userId: string }>((resolve) => {
+    setTimeout(() => {
+      resolve({ userId: '1234-5678-9101' }); // 예제 userId
+    }, 500); // API 응답 딜레이 (0.5초)
+  });
+};
+
+// 명함 공개 여부 확인
+export const mockGetUserCheckPrimaryPublicBusinessCards = async (userId: string) => {
+  return new Promise<{
+    business_card_id: string;
+    user_id: string;
+    is_primary: boolean;
+    is_public: boolean;
+  }>((resolve) => {
+    setTimeout(() => {
+      resolve(
+        { business_card_id: 'card-456', user_id: userId, is_primary: true, is_public: false }, // 대표 명함
+      );
+    }, 500);
+  });
+};
+
+// 명함 공개 여부 업데이트 (예제)
+export const mockUpdateBusinessCardVisibility = async (userId: string) => {
+  return new Promise<{ is_public: boolean }>((resolve) => {
+    setTimeout(() => {
+      console.log(`✅ ${userId} 사용자의 대표 명함이 공개되었습니다.`);
+      resolve({ is_public: true });
+    }, 500);
+  });
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -4,6 +4,11 @@ import { XIcon } from 'lucide-react';
 
 import { cn } from '@lib/utils';
 
+// Radix의 DialogPrimitive.Content에서 파생된 타입을 확장
+interface CustomDialogContentProps extends React.ComponentProps<typeof DialogPrimitive.Content> {
+  hideCloseButton?: boolean; // 사용자 정의 prop
+}
+
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
@@ -39,8 +44,9 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  hideCloseButton = false,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: CustomDialogContentProps) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -53,10 +59,19 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {/* hideCloseButton이 아닐 때만 기본 닫기 버튼을 보여줌 */}
+        {!hideCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className={cn(
+              'absolute top-4 right-4 rounded-xs opacity-70 transition-opacity',
+              'hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none',
+            )}
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   );

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -3,10 +3,19 @@ import { Drawer as DrawerPrimitive } from 'vaul';
 
 import { cn } from '@lib/utils';
 
-function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+type DrawerProps = React.PropsWithChildren<
+  React.ComponentProps<typeof DrawerPrimitive.Root> & {
+    handleOnly?: boolean;
+  }
+>;
+
+interface DrawerContentProps extends React.ComponentProps<typeof DrawerPrimitive.Content> {
+  hideIndicator?: boolean;
 }
 
+function Drawer({ handleOnly = false, ...props }: DrawerProps) {
+  return <DrawerPrimitive.Root handleOnly={handleOnly} data-slot="drawer" {...props} />;
+}
 function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
@@ -38,8 +47,9 @@ function DrawerOverlay({
 function DrawerContent({
   className,
   children,
+  hideIndicator = false,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: DrawerContentProps) {
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
@@ -55,7 +65,10 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        {/* hideIndicator가 false일 때만 인디케이터 렌더링 */}
+        {!hideIndicator && (
+          <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        )}
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>

--- a/src/components/ui/dropDown.tsx
+++ b/src/components/ui/dropDown.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { ChevronDown } from 'lucide-react';
+import clsx from 'clsx';
+
+interface DropDownProps {
+  options: string[];
+  selected: string;
+  onSelect: (value: string) => void;
+  placeholder?: string;
+  className?: string; // 커스텀 스타일링을 위한 className 추가
+  menuClassName?: string; // 메뉴 스타일링을 위한 className 추가
+  disabled?: boolean; // 비활성화 여부
+}
+
+const DropDown: React.FC<DropDownProps> = ({
+  options,
+  selected,
+  onSelect,
+  placeholder = '선택',
+  className = '',
+  menuClassName = '',
+  disabled = false,
+}) => {
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        className={clsx(
+          'flex items-center justify-between px-4 py-2 bg-gray-700 text-white rounded-lg cursor-pointer w-40',
+          className,
+          { 'cursor-not-allowed': disabled },
+        )}
+        disabled={disabled}
+      >
+        <span>{disabled ? '-' : selected || placeholder}</span>
+        <ChevronDown className="w-4 h-4 text-gray-400" />
+      </DropdownMenu.Trigger>
+
+      {!disabled && (
+        <DropdownMenu.Content
+          className={clsx(
+            'bg-gray-800 text-white rounded-lg mt-2 shadow-lg p-2 w-40',
+            menuClassName,
+          )}
+        >
+          {options.map((option) => (
+            <DropdownMenu.Item
+              key={option}
+              onSelect={() => onSelect(option)}
+              className="px-4 py-2 cursor-pointer hover:bg-gray-700 rounded-md"
+            >
+              {option}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      )}
+    </DropdownMenu.Root>
+  );
+};
+
+export default DropDown;

--- a/src/pages/NetworkingListPage/NetworkingListPage.tsx
+++ b/src/pages/NetworkingListPage/NetworkingListPage.tsx
@@ -1,7 +1,221 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import FullScreenPopup from '@components/NetworkingListPage/FullScreenPopup';
+import BusinessCardConsentSheet from '@components/NetworkingListPage/BusinessCardConsentSheet';
+import { useNavigate } from 'react-router-dom';
+import {
+  mockGetUserCheckPrimaryPublicBusinessCards,
+  mockUpdateBusinessCardVisibility,
+} from '@components/NetworkingListPage/MockApi';
+import DropDown from '@components/ui/dropDown';
 
-const NetworkingListPage = (): React.JSX.Element => {
-  return <div></div>;
+// 필터링 된 데이터가 이렇게 왔다고 가정...
+const profiles = [
+  { id: '1', userId: '101', name: '유현상', role: 'Development', detail: '프론트엔드' },
+  { id: '2', userId: '102', name: '이종혁', role: 'Development', detail: '백엔드' },
+  { id: '3', userId: '103', name: '조혜주', role: 'Design', detail: 'UI/UX 디자인' },
+  { id: '4', userId: '104', name: '김해담', role: 'Design', detail: '그래픽 디자인' },
+  { id: '5', userId: '105', name: '최*서', role: 'PM / 기획', detail: '프로덕트 매니저' },
+  { id: '6', userId: '106', name: '유*민', role: 'PM / 기획', detail: '게임 기획' },
+  { id: '7', userId: '107', name: '배*진', role: 'Data & AI', detail: '데이터 사이언스' },
+  { id: '8', userId: '108', name: '조*영', role: 'Data & AI', detail: 'AI 엔지니어' },
+  { id: '9', userId: '109', name: '배*진', role: 'Operation & Others', detail: 'IT 컨설팅' },
+  { id: '10', userId: '110', name: '조*영', role: 'Operation & Others', detail: '기술 지원' },
+];
+
+const roles = ['All', 'Development', 'Design', 'PM / 기획', 'Data & AI', 'Operation & Others'];
+
+const detailsMap = {
+  Development: [
+    'All',
+    '프론트엔드',
+    '백엔드',
+    '풀스택',
+    '모바일',
+    '데브옵스',
+    '데이터 엔지니어링',
+    '임베디드',
+    'QA/ 테스트 엔지니어',
+    '게임 개발',
+    '블록체인 개발',
+  ],
+  Design: [
+    'All',
+    'UI/UX 디자인',
+    '제품 디자인',
+    '그래픽 디자인',
+    '모션 그래픽',
+    '브랜딩 디자인',
+    '일러스트레이션',
+    '3D 디자인',
+    '게임 아트',
+  ],
+  'PM / 기획': [
+    'All',
+    '프로덕트 매니저',
+    '프로젝트 매니저',
+    '서비스 기획',
+    '게임 기획',
+    '데이터 분석',
+    '마케팅 기획',
+    'U/UX 리서치',
+  ],
+  'Data & AI': [
+    'All',
+    '데이터 사이언스',
+    'AI 엔지니어링',
+    '머신러닝 엔지니어',
+    'BI/ 데이터 애널리스트',
+    '빅데이터 엔지니어링',
+  ],
+  'Operation & Others': [
+    'All',
+    'IT 컨설팅',
+    '기술 지원',
+    '보안',
+    'DBA',
+    '네트워크 엔지니어',
+    '클라우드 엔지니어',
+  ],
 };
 
-export default NetworkingListPage;
+const NetworkingList: React.FC = (): React.JSX.Element => {
+  const [userId] = useState('101'); // 현재 로그인한 사용자 ID (목데이터)
+  const navigate = useNavigate();
+  const [selectedRole, setSelectedRole] = useState('All');
+  const [selectedDetail, setSelectedDetail] = useState('All');
+
+  const [showPopup, setShowPopup] = useState(false);
+  const [showConsentSheet, setShowConsentSheet] = useState(false);
+  const [, setIsPublic] = useState<boolean | null>(null);
+
+  const filteredProfiles = profiles.filter((profile) => {
+    const roleMatch = selectedRole === 'All' || profile.role === selectedRole;
+    const detailMatch = selectedDetail === 'All' || profile.detail === selectedDetail;
+
+    return roleMatch && detailMatch;
+  });
+
+  useEffect(() => {
+    console.log('선택된 분야:', selectedRole);
+    console.log('선택된 세부 분야:', selectedDetail);
+  }, [selectedRole, selectedDetail]);
+
+  useEffect(() => {
+    const hasSeenPopup = localStorage.getItem('seenNetworkingPopup');
+
+    if (!hasSeenPopup) {
+      setShowPopup(true); // 풀팝업 먼저 띄우기
+    } else {
+      fetchUserData();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!showPopup) {
+      fetchUserData(); // 풀팝업이 닫히고 나서 실행
+    }
+  }, [showPopup]);
+
+  const fetchUserData = async () => {
+    const data = await mockGetUserCheckPrimaryPublicBusinessCards(userId);
+    console.log('현재 명함 공개 여부:', data.is_public);
+    setIsPublic(data.is_public);
+
+    if (!data.is_public) {
+      setShowConsentSheet(true);
+    }
+  };
+
+  // X 버튼으로 닫을 때: 단순히 팝업을 닫음 (다음에 다시 뜰 수 있음)
+  const handlePopupXClose = () => {
+    setShowPopup(false);
+  };
+
+  // "다시 보지 않기" 버튼 클릭 시: 팝업 닫고 로컬스토리지에 기록
+  const handleDontShowPopup = () => {
+    setShowPopup(false);
+    localStorage.setItem('seenNetworkingPopup', 'true');
+  };
+
+  const handleConsentAgree = async () => {
+    const result = await mockUpdateBusinessCardVisibility(userId);
+    if (result.is_public) {
+      setIsPublic(true);
+      setShowConsentSheet(false);
+    }
+  };
+
+  const handleRoleSelect = (role: string) => {
+    setSelectedRole(role);
+    setSelectedDetail('All'); // 역할 선택 시 세부 분야 초기화
+  };
+
+  const availableDetails =
+    selectedRole === 'All' ? ['All'] : detailsMap[selectedRole as keyof typeof detailsMap];
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white">
+      <header className="p-4 bg-gray-800 text-center text-lg font-semibold">네트워킹 리스트</header>
+
+      <div className="flex gap-2 p-4">
+        <DropDown
+          options={roles}
+          selected={selectedRole}
+          onSelect={handleRoleSelect}
+          placeholder="분야 선택"
+          className="w-48 bg-blue-700"
+          menuClassName="bg-blue-800 text-white shadow-lg"
+        />
+        <DropDown
+          options={availableDetails}
+          selected={selectedDetail}
+          onSelect={setSelectedDetail}
+          placeholder="세부 분야 선택"
+          className="w-48 bg-green-700"
+          menuClassName="bg-green-800 text-white shadow-lg"
+          disabled={selectedRole === 'All'} // 역할 선택 전에는 비활성화
+        />
+      </div>
+
+      <div className="px-4 mt-4">
+        {filteredProfiles.map((profile) => (
+          <div
+            key={profile.id}
+            className="flex items-center gap-4 bg-gray-800 p-4 rounded-lg mb-2 cursor-pointer"
+            onClick={() => navigate(`/${profile.userId}/${profile.id}`)}
+          >
+            <div className="w-12 h-12 bg-gray-700 rounded-full flex items-center justify-center text-sm">
+              profile
+            </div>
+            <div>
+              <p className="font-semibold">{profile.name}</p>
+              <p className="text-gray-400">
+                <span className="font-bold">{profile.role}</span> | {profile.detail}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="fixed bottom-0 left-0 w-full bg-gray-700 py-3 text-center text-white">
+        네비게이션 바
+      </div>
+
+      <FullScreenPopup
+        open={showPopup}
+        onClose={handlePopupXClose} // X 버튼용
+        onDontShowAgain={handleDontShowPopup} // "다시 보지 않기"용
+      />
+
+      {!showPopup && (
+        <BusinessCardConsentSheet
+          open={showConsentSheet}
+          onClose={() => setShowConsentSheet(false)}
+          onAgree={handleConsentAgree}
+        />
+      )}
+    </div>
+  );
+};
+
+export default NetworkingList;

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
 const NotFoundPage = (): React.JSX.Element => {
-  return <div></div>;
+  return (
+    <div>
+      <h1>Not Found Page</h1>
+    </div>
+  );
 };
 
 export default NotFoundPage;

--- a/src/pages/UserCardPage/UserCardPage.tsx
+++ b/src/pages/UserCardPage/UserCardPage.tsx
@@ -1,7 +1,84 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import Card from '@components/NetworkingListPage/Card';
+import AddModal from '@components/NetworkingListPage/AddModal';
+import { Check, Plus } from 'lucide-react';
 
-const UserCardPage = (): React.JSX.Element => {
-  return <div></div>;
+interface BusinessCard {
+  company: string;
+  name: string;
+  role: string;
+  experience: string;
+  skills: string[];
+}
+
+const UserCardPage: React.FC = (): React.JSX.Element => {
+  const { userId, businessCardId } = useParams();
+  const [businessCard, setBusinessCard] = useState<BusinessCard | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+
+  useEffect(() => {
+    // TODO: 실제 API 요청으로 변경
+    const fetchBusinessCard = async () => {
+      const mockData: BusinessCard = {
+        company: '대박회사',
+        name: '홍길동',
+        role: 'Developer',
+        experience: '프론트엔드 n년차',
+        skills: ['JavaScript', 'Git', '풀스택', 'MySQL'],
+      };
+      setBusinessCard(mockData);
+    };
+    fetchBusinessCard();
+  }, [userId, businessCardId]);
+
+  if (!businessCard) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-white">로딩 중...</div>
+    );
+  }
+
+  // + 버튼 클릭 시 모달 열고 버튼 상태 변경
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+    setIsChecked(true); // 버튼 상태 체크로 변경
+  };
+
+  // 모달 닫기 시 버튼 원상복귀
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white flex flex-col justify-between flex-grow">
+      {/* 헤더 */}
+      <header className="p-4 bg-gray-800 text-center text-lg font-semibold">명함 상세보기</header>
+
+      <div className="relative flex flex-col items-center justify-center flex-grow">
+        <Card isGlossy={true} isMobile={false} isChat={false} />
+
+        {/* 버튼 애니메이션 (Tailwind 사용) */}
+        <button
+          onClick={handleOpenModal}
+          className={`w-16 h-16 mt-10 flex items-center justify-center rounded-full bg-green-500 cursor-pointer shadow-lg 
+            transition-all duration-300 transform ${isChecked ? 'scale-110' : 'scale-100'}`}
+        >
+          {isChecked ? (
+            <Check size={32} className="text-white transition-opacity duration-200" />
+          ) : (
+            <Plus size={32} className="text-white transition-opacity duration-200" />
+          )}
+        </button>
+      </div>
+
+      {/* 하단 네비게이션 */}
+      <div className="w-full bg-gray-700 py-3 text-center text-white">네비게이션 바</div>
+
+      {/* 모달 */}
+      <AddModal isOpen={isModalOpen} onClose={handleCloseModal} />
+    </div>
+  );
 };
 
 export default UserCardPage;

--- a/src/routes/RoutePath.ts
+++ b/src/routes/RoutePath.ts
@@ -13,6 +13,7 @@ const RoutePaths = {
   PREMIUM: '/premium',
   NETWORKINGCLUBS: '/networkingclubs',
   NETWORKINGLIST: '/networkinglist',
+  BUSINESS_CARD_DETAIL: '/:userId/:businessCardId', // 네트워킹 리스트에서 명함 상세 페이지 경로 추가
 };
 
 export default RoutePaths;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -33,6 +33,7 @@ const AppRouter = () => {
       <Route path={`${RoutePaths.EVENTS}${RoutePaths.PREMIUM}`} element={<PremiumEventPage />} />
       <Route path={RoutePaths.NETWORKINGCLUBS} element={<NetworkingClubPage />} />
       <Route path={RoutePaths.NETWORKINGLIST} element={<NetworkingListPage />} />
+      <Route path={RoutePaths.BUSINESS_CARD_DETAIL} element={<UserCardPage />} />
       <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );


### PR DESCRIPTION
## 연관 이슈
- #31 

## 작업 요약
- 풀팝업창 로직 구현, 바텀시트 및 명함 공개/비공개 설정 로직 구현
- 리스트 필터링 기능 구현
- 상대방 명함 추가 로직 구현

## 작업 상세 설명
- 의존성 추가
```
npm install @radix-ui/react-dropdown-menu
```

- 리스트 필터링은 분야 -> 세부분야 를 걸쳐서 필터링 가능
- 풀팝업창은 사용자가 2가지 상황에 따라 다름
  1. 맨위 오른쪽 상단 누를 시 -> 팝업창이 다시 나옴
  2. 다시보지 않기 누를 시 -> 로컬스토리지에 저장되어서 다시 보이지 않음
- 상대방 명함에서 + 누르면 체크표시와 모달창이 뜨도록 구현

## Preview 이미지 (필요시)
