### PR TITLE
vercel 경로 설정 파일 추가

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
-vercel 경로 설정 파일 추가

## 연관 이슈
- #42

## 작업 요약
> Vercel 경로 설정 파일 추가

## 작업 상세 설명
- GPT 曰
```
Vercel에서 페이지 이동 시 404: NOT_FOUND 오류가 발생하는 이유는 주로 React Router와 같은 클라이언트 사이드 라우팅을 사용하는 프로젝트에서, Vercel이 특정 경로를 처리할 수 없기 때문입니다. 이는 서버가 해당 경로를 인식하지 못하고, 기본적으로 index.html로 리디렉션되지 않아서 발생합니다.

아래는 이 문제를 해결하기 위한 단계별 가이드입니다.

1. 문제 원인
React Router와 같은 클라이언트 사이드 라우팅 사용:

React Router는 브라우저에서 경로를 처리하지만, Vercel은 기본적으로 서버에서 요청된 경로를 처리하려고 시도합니다.

예를 들어 /about 경로를 새로고침하면, Vercel은 /about에 해당하는 정적 파일을 찾으려고 하지만, 해당 파일이 없으면 404 오류가 발생합니다.

Vercel의 기본 설정 문제:

Vercel은 기본적으로 index.html 파일을 루트 디렉토리에서 찾습니다. 하지만 라우팅 설정이 없으면 다른 경로(/about, /user/1 등)는 처리되지 않습니다.
```

## 리뷰 요구사항
> 리뷰 예상 시간 및 집중 리뷰 부분

## Preview 이미지 (필요시)
