### PR TITLE
유저 페이지 (명함 리스트) 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "dayjs": "^1.11.13",
         "dom-to-image": "^2.6.0",
         "dom-to-image-more": "^3.5.0",
+        "embla-carousel-react": "^8.5.2",
         "file-saver": "^2.0.5",
         "html5-qrcode": "^2.3.8",
         "lucide-react": "^0.479.0",
@@ -3646,6 +3647,34 @@
       "integrity": "sha512-DFptFef3iktoKlFQK/afbo274/XNWD00Am0xa7M8FZUepHlHT8PEuiNBoRfFHbH1okqN58AlhbJ4QTkcnXorjA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.5.2.tgz",
+      "integrity": "sha512-xQ9oVLrun/eCG/7ru3R+I5bJ7shsD8fFwLEY7yPe27/+fDHCNj0OT5EoG5ZbFyOxOcG6yTwW8oTz/dWyFnyGpg==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.5.2.tgz",
+      "integrity": "sha512-Tmx+uY3MqseIGdwp0ScyUuxpBgx5jX1f7od4Cm5mDwg/dptEiTKf9xp6tw0lZN2VA9JbnVMl/aikmbc53c6QFA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.5.2",
+        "embla-carousel-reactive-utils": "8.5.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.5.2.tgz",
+      "integrity": "sha512-QC8/hYSK/pEmqEdU1IO5O+XNc/Ptmmq7uCB44vKplgLKhB/l0+yvYx0+Cv0sF6Ena8Srld5vUErZkT+yTahtDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.5.2"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,6 +1496,7 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.6.tgz",
       "integrity": "sha512-no3X7V5fD487wab/ZYSHXq3H37u4NVeLDKI/Ks724X/eEFSSEFYZxWgsIlr1UBeEyDaM29HM5x9p1Nv8DuTYPA==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "dayjs": "^1.11.13",
     "dom-to-image": "^2.6.0",
     "dom-to-image-more": "^3.5.0",
+    "embla-carousel-react": "^8.5.2",
     "file-saver": "^2.0.5",
     "html5-qrcode": "^2.3.8",
     "lucide-react": "^0.479.0",

--- a/src/components/SignupPage/FirstStep.tsx
+++ b/src/components/SignupPage/FirstStep.tsx
@@ -18,7 +18,7 @@ const FirstStep: React.FC<FirstStepProps> = ({ nextStep }) => {
 
   // 다음 단계로 이동
   const handleNextStep = async () => {
-    const isValid = await trigger(['userId', 'email', 'password', 'confirmPassword']); // userId 유효성 검사 추가
+    const isValid = await trigger(['nickname', 'email', 'password', 'confirmPassword']); // userId 유효성 검사 추가
     if (isValid) {
       nextStep(); // 유효성 검사를 통과하면 다음 단계로 이동
     }
@@ -53,7 +53,7 @@ const FirstStep: React.FC<FirstStepProps> = ({ nextStep }) => {
         </label>
         <input
           id="userId"
-          {...register('userId')}
+          {...register('nickname')}
           placeholder="아이디"
           className={`rounded-md border ${
             errors.userId ? 'border-red-500' : 'border-gray-600'

--- a/src/components/SignupPage/Signup.tsx
+++ b/src/components/SignupPage/Signup.tsx
@@ -17,7 +17,7 @@ const SignupForm = (): React.JSX.Element => {
     resolver: zodResolver(schema),
     defaultValues: {
       name: '',
-      userId: '',
+      nickname: '',
       email: '',
       password: '',
       confirmPassword: '',

--- a/src/components/SignupPage/ThirdStep.tsx
+++ b/src/components/SignupPage/ThirdStep.tsx
@@ -18,13 +18,13 @@ const ThirdStep: React.FC<ThirdStepProps> = ({ prevStep, nextStep }) => {
   const onSubmit = async (formData: SignupData) => {
     try {
       // 1. Supabase Auth로 회원가입
-      const { data: authData, error: authError } = await supabase.auth.signUp({
+      const { error: authError } = await supabase.auth.signUp({
         email: formData.email,
         password: formData.password,
         options: {
           data: {
             name: formData.name,
-            userId: formData.userId,
+            nickname: formData.nickname,
           },
         },
       });
@@ -35,20 +35,11 @@ const ThirdStep: React.FC<ThirdStepProps> = ({ prevStep, nextStep }) => {
         return;
       }
 
-      // 2. `auth.users` → `public.users` 데이터 복사는 트리거로 자동 처리
-      const userId = authData.user?.id; // Supabase Auth에서 생성된 사용자 ID 가져오기
-
-      if (!userId) {
-        console.error('User ID not found after Auth signup.');
-        alert('사용자 ID를 가져오는 데 실패했습니다.');
-        return;
-      }
-
       // 3. 명함 생성은 트리거로 자동 처리되므로, 직무 및 세부 직무 추가
       const { data: businessCardData, error: businessCardFetchError } = await supabase
         .from('business_cards')
         .select('business_card_id')
-        .eq('user_id', userId)
+        .eq('nickname', formData.nickname)
         .single();
 
       if (businessCardFetchError || !businessCardData) {
@@ -86,7 +77,7 @@ const ThirdStep: React.FC<ThirdStepProps> = ({ prevStep, nextStep }) => {
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
       <h2 className="text-lg text-white">입력된 정보가 맞나요?</h2>
       <p className="text-sm text-gray-300">이름: {getValues('name')}</p>
-      <p className="text-sm text-gray-300">아이디: {getValues('userId')}</p>
+      <p className="text-sm text-gray-300">아이디: {getValues('nickname')}</p>
       <p className="text-sm text-gray-300">이메일: {getValues('email')}</p>
       <p className="text-sm text-gray-300">직무: {getValues('fieldsOfExpertise')}</p>
       <p className="text-sm text-gray-300">세부 직무: {getValues('subExpertise')}</p>

--- a/src/components/SignupPage/signupSchema.ts
+++ b/src/components/SignupPage/signupSchema.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const schema = z
   .object({
     name: z.string().min(1, { message: '이름은 필수입니다.' }),
-    userId: z
+    nickname: z
       .string()
       .min(4, { message: '아이디는 최소 4자 이상이어야 합니다' })
       .max(20, { message: '아이디는 최대 20자까지 가능합니다' })

--- a/src/components/commons/Card/Card.tsx
+++ b/src/components/commons/Card/Card.tsx
@@ -19,7 +19,7 @@ interface CardProps {
   isInteractive?: boolean;
   cardId?: string; // 명함 ID
   nickname?: string;
-  cardColor: string;
+  cardColor?: string;
   refetch?: () => void;
 }
 
@@ -131,6 +131,25 @@ const Card = ({
     return `${usePound ? '#' : ''}${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
   };
 
+  const getCardColor = (): string => {
+    if (cardColor && (!cardData || !cardData.cardType)) return cardColor;
+
+    switch (cardData?.cardType.toLowerCase()) {
+      case 'dawn':
+        return '#E49759'; // 보라색
+      case 'morning':
+        return '#FFD700'; // 노란색
+      case 'day':
+        return '#1E90FF'; // 파란색
+      case 'evening':
+        return '#FD5E53'; // 주황색
+      case 'night':
+        return '#002BFF'; // 남색
+      default:
+        return '#002BFF'; // 기본 파란색
+    }
+  };
+
   // 카드 내용 렌더링 함수
   const renderCardContent = () => (
     <div className="text-white text-center flex flex-col justify-center items-center gap-2">
@@ -178,8 +197,8 @@ const Card = ({
         ref={cardRef}
         className={`w-[80mm] h-[128mm] rounded-3xl shadow-lg transform-style-preserve-3d transition-transform duration-300 ease-out relative flex flex-col justify-center items-center gap-2 will-change-transform`}
         style={{
-          backgroundImage: `linear-gradient(to bottom right, ${cardColor}, ${adjustColorBrightness(
-            cardColor,
+          backgroundImage: `linear-gradient(to bottom right, ${getCardColor()}, ${adjustColorBrightness(
+            getCardColor(),
             -30,
           )})`,
         }}

--- a/src/components/commons/Card/Card.tsx
+++ b/src/components/commons/Card/Card.tsx
@@ -5,14 +5,17 @@ import { Icon } from '@iconify/react/dist/iconify.js';
 interface CardProps {
   isGlossy: boolean;
   isMobile: boolean;
-  isChat: boolean;
+  isInteractive?: boolean;
+  cardId?: string;
   cardColor: string;
 }
 
-const Card = ({ isGlossy, isMobile, cardColor }: CardProps) => {
+const Card = ({ isGlossy, isMobile, isInteractive = true, cardColor }: CardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
 
   const handleMove = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
+    if (!isInteractive) return; // 3D 효과 비활성화 시 이벤트 처리 중단
+
     const card = e.currentTarget as HTMLDivElement;
     const rect = card.getBoundingClientRect();
     const clientX = isMobile
@@ -39,6 +42,8 @@ const Card = ({ isGlossy, isMobile, cardColor }: CardProps) => {
   };
 
   const handleEnter = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
+    if (!isInteractive) return; // 3D 효과 비활성화 시 이벤트 처리 중단
+
     const card = e.currentTarget as HTMLDivElement;
     const glossyOverlay = card.querySelector('.overlay.glossy') as HTMLElement;
 
@@ -48,6 +53,8 @@ const Card = ({ isGlossy, isMobile, cardColor }: CardProps) => {
   };
 
   const handleLeave = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
+    if (!isInteractive) return; // 3D 효과 비활성화 시 이벤트 처리 중단
+
     const card = e.currentTarget as HTMLDivElement;
 
     // 카드 초기화
@@ -93,12 +100,12 @@ const Card = ({ isGlossy, isMobile, cardColor }: CardProps) => {
               -30,
             )})`,
           }}
-          onMouseEnter={!isMobile ? handleEnter : undefined}
-          onMouseMove={!isMobile ? handleMove : undefined}
-          onMouseLeave={!isMobile ? handleLeave : undefined}
-          onTouchStart={isMobile ? handleEnter : undefined}
-          onTouchMove={isMobile ? handleMove : undefined}
-          onTouchEnd={isMobile ? handleLeave : undefined}
+          onMouseEnter={!isMobile && isInteractive ? handleEnter : undefined}
+          onMouseMove={!isMobile && isInteractive ? handleMove : undefined}
+          onMouseLeave={!isMobile && isInteractive ? handleLeave : undefined}
+          onTouchStart={isMobile && isInteractive ? handleEnter : undefined}
+          onTouchMove={isMobile && isInteractive ? handleMove : undefined}
+          onTouchEnd={isMobile && isInteractive ? handleLeave : undefined}
         >
           {isGlossy && (
             <div className="overlay glossy absolute top-0 left-0 w-full h-full rounded-inherit pointer-events-none transition-opacity duration-300"></div>

--- a/src/components/commons/Card/Card.tsx
+++ b/src/components/commons/Card/Card.tsx
@@ -26,9 +26,13 @@ const Card = ({
   const cardRef = useRef<HTMLDivElement>(null);
 
   // 명함 데이터를 가져오는 RTK Query 훅
-  const { data: cardData, isLoading: isCardLoading } = useGetBusinessCardByIdQuery(cardId || '');
+  const { data: cardData, isLoading: isCardLoading } = useGetBusinessCardByIdQuery(cardId || '', {
+    skip: !cardId,
+  });
 
-  const { data: userData, isLoading: isUserLoading } = useGetUserByNicknameQuery(nickname || '');
+  const { data: userData, isLoading: isUserLoading } = useGetUserByNicknameQuery(nickname || '', {
+    skip: !nickname,
+  });
 
   const handleMove = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
     if (!isInteractive) return;

--- a/src/components/commons/Card/Card.tsx
+++ b/src/components/commons/Card/Card.tsx
@@ -5,6 +5,7 @@ import {
   useDeleteBusinessCardMutation,
   useGetBusinessCardByIdQuery,
   useGetUserByNicknameQuery,
+  useSetPrimaryBusinessCardMutation,
 } from '@features/BusinessCard/api/businessCardApi';
 import {
   DropdownMenu,
@@ -44,9 +45,15 @@ const Card = ({
   });
 
   const [deleteBusinessCard] = useDeleteBusinessCardMutation();
+  const [setPrimaryBusinessCard] = useSetPrimaryBusinessCardMutation();
 
   const handleDelete = async () => {
     if (!cardId) return;
+
+    if (cardData?.isPrimary) {
+      alert('대표 명함은 삭제할 수 없습니다.');
+      return;
+    }
 
     if (confirm('정말로 이 명함을 삭제하시겠습니까?')) {
       try {
@@ -57,6 +64,18 @@ const Card = ({
         console.error('명함 삭제 중 오류 발생:', error);
         alert('명함 삭제 중 오류가 발생했습니다.');
       }
+    }
+  };
+
+  const handleSetPrimary = async () => {
+    if (!cardId) return;
+    try {
+      await setPrimaryBusinessCard(cardId).unwrap();
+      alert('대표 명함으로 설정되었습니다!');
+      refetch?.();
+    } catch (error) {
+      console.error('대표 명함 설정 중 오류 발생:', error);
+      alert('대표 명함 설정 중 오류가 발생했습니다.');
     }
   };
 
@@ -183,6 +202,9 @@ const Card = ({
 
   return (
     <div className="flex justify-center items-center h-full perspective-[1500px]">
+      {cardData?.isPrimary && (
+        <Icon icon="mdi:crown" className="absolute top-[10px] text-yellow-400 w-8 h-8 z-50" />
+      )}
       <DropdownMenu>
         <DropdownMenuTrigger className="absolute top-3 right-3 cursor-pointer z-50">
           <Icon icon="mdi:dots-vertical" className="w-6 h-6 text-black cursor-pointer" />
@@ -190,6 +212,12 @@ const Card = ({
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={handleDelete} className="text-red-500 hover:text-red-700">
             삭제
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={handleSetPrimary}
+            className="cursor-pointer px-4 py-2 hover:bg-gray-700 rounded-md"
+          >
+            대표 명함 설정
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/components/commons/Card/Card.tsx
+++ b/src/components/commons/Card/Card.tsx
@@ -2,9 +2,16 @@ import { useRef, MouseEvent, TouchEvent } from 'react';
 import { Badge } from '@components/ui/badge';
 import { Icon } from '@iconify/react/dist/iconify.js';
 import {
+  useDeleteBusinessCardMutation,
   useGetBusinessCardByIdQuery,
   useGetUserByNicknameQuery,
 } from '@features/BusinessCard/api/businessCardApi';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@components/ui/dropdown-menu';
 
 interface CardProps {
   isGlossy: boolean;
@@ -13,6 +20,7 @@ interface CardProps {
   cardId?: string; // 명함 ID
   nickname?: string;
   cardColor: string;
+  refetch?: () => void;
 }
 
 const Card = ({
@@ -22,6 +30,7 @@ const Card = ({
   cardId,
   nickname,
   cardColor,
+  refetch,
 }: CardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -33,6 +42,23 @@ const Card = ({
   const { data: userData, isLoading: isUserLoading } = useGetUserByNicknameQuery(nickname || '', {
     skip: !nickname,
   });
+
+  const [deleteBusinessCard] = useDeleteBusinessCardMutation();
+
+  const handleDelete = async () => {
+    if (!cardId) return;
+
+    if (confirm('정말로 이 명함을 삭제하시겠습니까?')) {
+      try {
+        await deleteBusinessCard(cardId).unwrap();
+        alert('명함이 성공적으로 삭제되었습니다!');
+        refetch?.();
+      } catch (error) {
+        console.error('명함 삭제 중 오류 발생:', error);
+        alert('명함 삭제 중 오류가 발생했습니다.');
+      }
+    }
+  };
 
   const handleMove = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
     if (!isInteractive) return;
@@ -138,6 +164,16 @@ const Card = ({
 
   return (
     <div className="flex justify-center items-center h-full perspective-[1500px]">
+      <DropdownMenu>
+        <DropdownMenuTrigger className="absolute top-3 right-3 cursor-pointer z-50">
+          <Icon icon="mdi:dots-vertical" className="w-6 h-6 text-black cursor-pointer" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={handleDelete} className="text-red-500 hover:text-red-700">
+            삭제
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <div
         ref={cardRef}
         className={`w-[80mm] h-[128mm] rounded-3xl shadow-lg transform-style-preserve-3d transition-transform duration-300 ease-out relative flex flex-col justify-center items-center gap-2 will-change-transform`}

--- a/src/components/commons/Card/Card.tsx
+++ b/src/components/commons/Card/Card.tsx
@@ -1,20 +1,37 @@
 import { useRef, MouseEvent, TouchEvent } from 'react';
 import { Badge } from '@components/ui/badge';
 import { Icon } from '@iconify/react/dist/iconify.js';
+import {
+  useGetBusinessCardByIdQuery,
+  useGetUserByNicknameQuery,
+} from '@features/BusinessCard/api/businessCardApi';
 
 interface CardProps {
   isGlossy: boolean;
   isMobile: boolean;
   isInteractive?: boolean;
-  cardId?: string;
+  cardId?: string; // 명함 ID
+  nickname?: string;
   cardColor: string;
 }
 
-const Card = ({ isGlossy, isMobile, isInteractive = true, cardColor }: CardProps) => {
+const Card = ({
+  isGlossy,
+  isMobile,
+  isInteractive = true,
+  cardId,
+  nickname,
+  cardColor,
+}: CardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
 
+  // 명함 데이터를 가져오는 RTK Query 훅
+  const { data: cardData, isLoading: isCardLoading } = useGetBusinessCardByIdQuery(cardId || '');
+
+  const { data: userData, isLoading: isUserLoading } = useGetUserByNicknameQuery(nickname || '');
+
   const handleMove = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
-    if (!isInteractive) return; // 3D 효과 비활성화 시 이벤트 처리 중단
+    if (!isInteractive) return;
 
     const card = e.currentTarget as HTMLDivElement;
     const rect = card.getBoundingClientRect();
@@ -30,10 +47,8 @@ const Card = ({ isGlossy, isMobile, isInteractive = true, cardColor }: CardProps
     const xAxis = (clientX - rect.left - rect.width / 2) / 15;
     const yAxis = (clientY - rect.top - rect.height / 2) / 15;
 
-    // 카드 각도 조절
     card.style.transform = `rotateY(${-xAxis}deg) rotateX(${yAxis}deg)`;
 
-    // 유광 효과 업데이트
     const glossyOverlay = card.querySelector('.overlay.glossy') as HTMLElement;
     if (glossyOverlay) {
       glossyOverlay.style.background = `radial-gradient(circle at ${mouseX}px ${mouseY}px, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0.03) 70%, transparent 100%)`;
@@ -42,7 +57,7 @@ const Card = ({ isGlossy, isMobile, isInteractive = true, cardColor }: CardProps
   };
 
   const handleEnter = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
-    if (!isInteractive) return; // 3D 효과 비활성화 시 이벤트 처리 중단
+    if (!isInteractive) return;
 
     const card = e.currentTarget as HTMLDivElement;
     const glossyOverlay = card.querySelector('.overlay.glossy') as HTMLElement;
@@ -53,14 +68,12 @@ const Card = ({ isGlossy, isMobile, isInteractive = true, cardColor }: CardProps
   };
 
   const handleLeave = (e: MouseEvent<HTMLDivElement> | TouchEvent<HTMLDivElement>) => {
-    if (!isInteractive) return; // 3D 효과 비활성화 시 이벤트 처리 중단
+    if (!isInteractive) return;
 
     const card = e.currentTarget as HTMLDivElement;
 
-    // 카드 초기화
     card.style.transform = 'rotateY(0deg) rotateX(0deg)';
 
-    // 유광 효과 초기화
     const glossyOverlay = card.querySelector('.overlay.glossy') as HTMLElement;
     if (glossyOverlay) {
       glossyOverlay.style.opacity = '0';
@@ -88,82 +101,67 @@ const Card = ({ isGlossy, isMobile, isInteractive = true, cardColor }: CardProps
     return `${usePound ? '#' : ''}${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
   };
 
-  return (
-    <>
-      <div className="flex justify-center items-center h-full perspective-[1500px]">
-        <div
-          ref={cardRef}
-          className={`w-[80mm] h-[128mm] rounded-3xl shadow-lg transform-style-preserve-3d transition-transform duration-300 ease-out relative flex flex-col justify-center items-center gap-2 will-change-transform`}
-          style={{
-            backgroundImage: `linear-gradient(to bottom right, ${cardColor}, ${adjustColorBrightness(
-              cardColor,
-              -30,
-            )})`,
-          }}
-          onMouseEnter={!isMobile && isInteractive ? handleEnter : undefined}
-          onMouseMove={!isMobile && isInteractive ? handleMove : undefined}
-          onMouseLeave={!isMobile && isInteractive ? handleLeave : undefined}
-          onTouchStart={isMobile && isInteractive ? handleEnter : undefined}
-          onTouchMove={isMobile && isInteractive ? handleMove : undefined}
-          onTouchEnd={isMobile && isInteractive ? handleLeave : undefined}
-        >
-          {isGlossy && (
-            <div className="overlay glossy absolute top-0 left-0 w-full h-full rounded-inherit pointer-events-none transition-opacity duration-300"></div>
-          )}
+  // 카드 내용 렌더링 함수
+  const renderCardContent = () => (
+    <div className="text-white text-center flex flex-col justify-center items-center gap-2">
+      <p className="font-bold text-2xl">{userData?.name || '이종혁'}</p>
+      <p className="font-bold text-xl">{cardData?.fieldsOfExpertise || '프론트엔드 개발자'}</p>
 
-          <div className="text-white text-center flex flex-col justify-center items-center gap-2">
-            <p className="font-bold text-2xl">이종혁</p>
-            <p className="font-bold text-xl">프론트엔드 개발자</p>
-
-            <div className="flex flex-col items-start gap-2">
-              <div className="flex items-center gap-2 text-sm">
-                <Icon icon="mdi-light:email" className="w-5 h-5" />
-                <span>E-mail: jonghyeok@example.com</span>
-              </div>
-
-              <div className="flex items-center gap-2 text-sm">
-                <Icon icon="mdi-light:phone" className="w-5 h-5" />
-                <span>Phone: +123-456-7890</span>
-              </div>
-
-              <div className="flex items-center gap-2 text-sm">
-                <Icon icon="uiw:github" className="w-5 h-5" />
-                <span>github.com/leejh5314</span>
-              </div>
-
-              <div className="flex items-center gap-2 text-sm">
-                <Icon icon="dashicons:instagram" className="w-5 h-5" />
-                <span>instagram.com/jonghyeok</span>
-              </div>
-            </div>
-
-            <div className="flex justify-center gap-2 mt-4">
-              <Badge
-                variant="outline"
-                className="flex text-white items-center gap-1 p-2 rounded-xl font-bold"
-              >
-                <Icon icon="logos:nextjs-icon" className="w-4 h-4" />
-                Next.js
-              </Badge>
-              <Badge
-                variant="outline"
-                className="flex text-white items-center gap-1 p-2 rounded-xl font-bold"
-              >
-                <Icon icon="logos:typescript-icon" className="w-4 h-4" />
-                TypeScript
-              </Badge>
-              <Badge
-                variant="outline"
-                className="flex text-white items-center gap-1 p-2 rounded-xl font-bold"
-              >
-                <Icon icon="logos:react" className="w-4 h-4" />
-                React
-              </Badge>
-            </div>
-          </div>
+      <div className="flex flex-col items-start gap-2">
+        <div className="flex items-center gap-2 text-sm">
+          <Icon icon="mdi-light:email" className="w-5 h-5" />
+          <span>{userData?.email || 'jonghyeok@example.com'}</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <Icon icon="mdi-light:user" className="w-5 h-5" />
+          <span>{cardData?.subExpertise || 'React / TypeScript'}</span>
         </div>
       </div>
-    </>
+
+      <div className="flex justify-center gap-2 mt-4">
+        {(cardData?.interests || ['Next.js', 'TypeScript', 'React']).map((interest) => (
+          <Badge
+            key={interest}
+            variant="outline"
+            className="flex text-white items-center gap-1 p-2 rounded-xl font-bold"
+          >
+            {interest}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="flex justify-center items-center h-full perspective-[1500px]">
+      <div
+        ref={cardRef}
+        className={`w-[80mm] h-[128mm] rounded-3xl shadow-lg transform-style-preserve-3d transition-transform duration-300 ease-out relative flex flex-col justify-center items-center gap-2 will-change-transform`}
+        style={{
+          backgroundImage: `linear-gradient(to bottom right, ${cardColor}, ${adjustColorBrightness(
+            cardColor,
+            -30,
+          )})`,
+        }}
+        onMouseEnter={!isMobile && isInteractive ? handleEnter : undefined}
+        onMouseMove={!isMobile && isInteractive ? handleMove : undefined}
+        onMouseLeave={!isMobile && isInteractive ? handleLeave : undefined}
+        onTouchStart={isMobile && isInteractive ? handleEnter : undefined}
+        onTouchMove={isMobile && isInteractive ? handleMove : undefined}
+        onTouchEnd={isMobile && isInteractive ? handleLeave : undefined}
+      >
+        {isGlossy && (
+          <div className="overlay glossy absolute top-0 left-0 w-full h-full rounded-inherit pointer-events-none transition-opacity duration-300"></div>
+        )}
+
+        {/* 조건부 렌더링 */}
+        {isCardLoading || isUserLoading ? (
+          <p className="text-white">Loading...</p>
+        ) : (
+          renderCardContent()
+        )}
+      </div>
+    </div>
   );
 };
 

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,228 @@
+import * as React from 'react';
+import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
+
+import { cn } from '@lib/utils';
+import { Button } from '@components/ui/button';
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: 'horizontal' | 'vertical';
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error('useCarousel must be used within a <Carousel />');
+  }
+
+  return context;
+}
+
+function Carousel({
+  orientation = 'horizontal',
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === 'horizontal' ? 'x' : 'y',
+    },
+    plugins,
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev();
+  }, [api]);
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext();
+  }, [api]);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        scrollPrev();
+      } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        scrollNext();
+      }
+    },
+    [scrollPrev, scrollNext],
+  );
+
+  React.useEffect(() => {
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
+
+  React.useEffect(() => {
+    if (!api) return;
+    onSelect(api);
+    api.on('reInit', onSelect);
+    api.on('select', onSelect);
+
+    return () => {
+      api?.off('select', onSelect);
+    };
+  }, [api, onSelect]);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation: orientation || (opts?.axis === 'y' ? 'vertical' : 'horizontal'),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn('relative', className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<'div'>) {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden" data-slot="carousel-content">
+      <div
+        className={cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<'div'>) {
+  const { orientation } = useCarousel();
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CarouselPrevious({
+  className,
+  variant = 'outline',
+  size = 'icon',
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -left-12 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+}
+
+function CarouselNext({
+  className,
+  variant = 'outline',
+  size = 'icon',
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute size-8 rounded-full',
+        orientation === 'horizontal'
+          ? 'top-1/2 -right-12 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className,
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+}
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+};

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,255 @@
+import * as React from "react"
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  )
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "text-muted-foreground ml-auto text-xs tracking-widest",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/features/BusinessCard/api/businessCardApi.ts
+++ b/src/features/BusinessCard/api/businessCardApi.ts
@@ -209,11 +209,34 @@ export const businessCardApi = createApi({
       },
       invalidatesTags: ['BusinessCard'],
     }),
+    deleteBusinessCard: builder.mutation<void, string>({
+      queryFn: async (cardId) => {
+        try {
+          const { error } = await supabase
+            .from('business_cards')
+            .delete()
+            .eq('business_card_id', cardId);
+
+          if (error) throw error;
+
+          return { data: undefined };
+        } catch (error) {
+          return {
+            error: {
+              message: error instanceof Error ? error.message : 'Unknown error',
+              name: error instanceof Error ? error.name : 'Error',
+            },
+          };
+        }
+      },
+      invalidatesTags: (_, __, cardId) => [{ type: 'BusinessCard', id: cardId }],
+    }),
   }),
 });
 
 export const {
   useGetBusinessCardByIdQuery,
   useAddBusinessCardMutation,
+  useDeleteBusinessCardMutation,
   useGetUserByNicknameQuery,
 } = businessCardApi;

--- a/src/features/BusinessCard/api/businessCardApi.ts
+++ b/src/features/BusinessCard/api/businessCardApi.ts
@@ -1,0 +1,162 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { PostgrestSingleResponse } from '@supabase/supabase-js';
+import { supabase } from '@utils/supabaseClient';
+
+// 명함 데이터 인터페이스 (카멜 케이스)
+export interface BusinessCard {
+  businessCardId: string;
+  cardName: string;
+  fieldsOfExpertise: string;
+  subExpertise: string;
+  company?: string;
+  interests?: string[];
+  phone?: string;
+  email?: string;
+  linkedin?: string;
+  businessWebsite?: string;
+  website?: string;
+  experienceYears?: number;
+  viewCount?: number;
+  isPublic?: boolean;
+  isPrimary?: boolean;
+  createdAt?: string;
+  qrImageUrl?: string;
+  nickname: string;
+  cardType: string;
+}
+
+interface DbBusinessCard {
+  business_card_id: string;
+  card_name: string;
+  fields_of_expertise: string;
+  sub_expertise: string;
+  company?: string;
+  interests?: string[]; // JSON 배열로 저장된 문자열 배열
+  phone?: string;
+  email?: string;
+  linkedin?: string;
+  business_website?: string;
+  website?: string;
+  experience_years?: number | null;
+  view_count?: number | null;
+  is_public?: boolean | null;
+  is_primary?: boolean | null;
+  created_at?: string | null;
+  qr_image_url?: string | null;
+  nickname: string;
+  card_type: string | null;
+}
+
+export interface User {
+  userId: string;
+  nickname: string;
+  email: string;
+  name: string;
+}
+
+export const businessCardApi = createApi({
+  reducerPath: 'businessCardApi',
+  baseQuery: fakeBaseQuery(),
+  tagTypes: ['BusinessCard', 'User'],
+  endpoints: (builder) => ({
+    getBusinessCardById: builder.query<BusinessCard | null, string>({
+      queryFn: async (cardId) => {
+        try {
+          const { data, error } = (await supabase
+            .from('business_cards')
+            .select(
+              `
+              business_card_id,
+              card_name,
+              fields_of_expertise,
+              sub_expertise,
+              company,
+              interests,
+              phone,
+              email,
+              linkedin,
+              business_website,
+              website,
+              experience_years,
+              view_count,
+              is_public,
+              is_primary,
+              created_at,
+              qr_image_url,
+              nickname,
+              card_type
+            `,
+            )
+            .eq('business_card_id', cardId)
+            .limit(1)
+            .single()) as PostgrestSingleResponse<DbBusinessCard>;
+
+          if (error) throw error;
+          if (!data) return { data: null };
+
+          // 스네이크 케이스 -> 카멜 케이스 변환
+          const transformedData: BusinessCard = {
+            businessCardId: data.business_card_id,
+            cardName: data.card_name,
+            fieldsOfExpertise: data.fields_of_expertise,
+            subExpertise: data.sub_expertise,
+            company: data.company ?? '',
+            interests: Array.isArray(data.interests) ? data.interests : [],
+            phone: data.phone ?? '',
+            email: data.email ?? '',
+            linkedin: data.linkedin ?? '',
+            businessWebsite: data.business_website ?? '',
+            website: data.website ?? '',
+            experienceYears: data.experience_years ?? 0,
+            viewCount: data.view_count ?? 0,
+            isPublic: data.is_public ?? true,
+            isPrimary: data.is_primary ?? false,
+            createdAt: data.created_at ?? '',
+            qrImageUrl: data.qr_image_url ?? '',
+            nickname: data.nickname ?? '',
+            cardType: data.card_type ?? 'day',
+          };
+
+          return { data: transformedData };
+        } catch (error) {
+          // 직렬화 가능한 에러 객체로 변환
+          return {
+            error: {
+              message: error instanceof Error ? error.message : 'Unknown error',
+              name: error instanceof Error ? error.name : 'Error',
+            },
+          };
+        }
+      },
+      providesTags: (_, __, cardId) => [{ type: 'BusinessCard', id: cardId }],
+    }),
+    getUserByNickname: builder.query<User | null, string>({
+      queryFn: async (nickname) => {
+        try {
+          const { data, error } = (await supabase
+            .from('users')
+            .select('user_id, nickname, email, name')
+            .eq('nickname', nickname)
+            .limit(1)
+            .single()) as PostgrestSingleResponse<User>;
+
+          if (error) throw error;
+
+          if (!data) return { data: null };
+          console.log(data);
+          return { data };
+        } catch (error) {
+          return {
+            error: {
+              message: error instanceof Error ? error.message : 'Unknown error',
+              name: error instanceof Error ? error.name : 'Error',
+            },
+          };
+        }
+      },
+      providesTags: (_, __, nickname) => [{ type: 'User', id: nickname }],
+    }),
+  }),
+});
+
+export const { useGetBusinessCardByIdQuery, useGetUserByNicknameQuery } = businessCardApi;

--- a/src/features/BusinessCard/api/businessCardApi.ts
+++ b/src/features/BusinessCard/api/businessCardApi.ts
@@ -143,7 +143,7 @@ export const businessCardApi = createApi({
           if (error) throw error;
 
           if (!data) return { data: null };
-          console.log(data);
+
           return { data };
         } catch (error) {
           return {
@@ -156,7 +156,64 @@ export const businessCardApi = createApi({
       },
       providesTags: (_, __, nickname) => [{ type: 'User', id: nickname }],
     }),
+    addBusinessCard: builder.mutation<BusinessCard, { nickname: string }>({
+      queryFn: async ({ nickname }) => {
+        try {
+          const { data, error } = await supabase
+            .from('business_cards')
+            .insert({
+              card_name: '', // 기본값
+              fields_of_expertise: '', // 기본값
+              sub_expertise: '', // 기본값
+              nickname, // 추가한 사람의 닉네임
+              is_public: false, // 기본값으로 비공개 설정
+              is_primary: false, // 대표 명함 아님
+              card_type: 'day', // 기본값으로 'day'
+            })
+            .select()
+            .single();
+
+          if (error) throw error;
+
+          const transformedData = {
+            businessCardId: data.business_card_id,
+            cardName: data.card_name,
+            fieldsOfExpertise: data.fields_of_expertise,
+            subExpertise: data.sub_expertise,
+            company: data.company ?? '',
+            interests: Array.isArray(data.interests) ? data.interests : [],
+            phone: data.phone ?? '',
+            email: data.email ?? '',
+            linkedin: data.linkedin ?? '',
+            businessWebsite: data.business_website ?? '',
+            website: data.website ?? '',
+            experienceYears: 0, // 기본값
+            viewCount: 0, // 기본값
+            isPublic: false, // 비공개
+            isPrimary: false, // 대표 명함 아님
+            createdAt: new Date().toISOString(), // 현재 시간
+            qrImageUrl: '',
+            nickname,
+            cardType: 'day',
+          };
+
+          return { data: transformedData };
+        } catch (error) {
+          return {
+            error:
+              error instanceof Error
+                ? { message: error.message, name: error.name }
+                : { message: 'Unknown Error', name: 'Error' },
+          };
+        }
+      },
+      invalidatesTags: ['BusinessCard'],
+    }),
   }),
 });
 
-export const { useGetBusinessCardByIdQuery, useGetUserByNicknameQuery } = businessCardApi;
+export const {
+  useGetBusinessCardByIdQuery,
+  useAddBusinessCardMutation,
+  useGetUserByNicknameQuery,
+} = businessCardApi;

--- a/src/features/BusinessCard/api/businessCardApi.ts
+++ b/src/features/BusinessCard/api/businessCardApi.ts
@@ -231,6 +231,31 @@ export const businessCardApi = createApi({
       },
       invalidatesTags: (_, __, cardId) => [{ type: 'BusinessCard', id: cardId }],
     }),
+    setPrimaryBusinessCard: builder.mutation<void, string>({
+      queryFn: async (cardId) => {
+        try {
+          const { error } = await supabase
+            .from('business_cards')
+            .update({ is_primary: true }) // is_primary를 true로 업데이트
+            .eq('business_card_id', cardId); // cardId 조건
+
+          if (error) throw error;
+
+          return { data: undefined };
+        } catch (error) {
+          return {
+            error: {
+              message: error instanceof Error ? error.message : 'Unknown error',
+              name: error instanceof Error ? error.name : 'Error',
+            },
+          };
+        }
+      },
+      invalidatesTags: (_, __, cardId) => [
+        { type: 'BusinessCard', id: cardId }, // 현재 대표 명함
+        { type: 'BusinessCard' }, // 모든 카드 목록 무효화
+      ],
+    }),
   }),
 });
 
@@ -239,4 +264,5 @@ export const {
   useAddBusinessCardMutation,
   useDeleteBusinessCardMutation,
   useGetUserByNicknameQuery,
+  useSetPrimaryBusinessCardMutation,
 } = businessCardApi;

--- a/src/features/UserPage/api/userCardListApi.ts
+++ b/src/features/UserPage/api/userCardListApi.ts
@@ -1,0 +1,36 @@
+import { createApi, fakeBaseQuery } from '@reduxjs/toolkit/query/react';
+import { supabase } from '@utils/supabaseClient';
+
+export const userCardListApi = createApi({
+  reducerPath: 'userCardListApi',
+  baseQuery: fakeBaseQuery(),
+  tagTypes: ['userCardList'],
+  endpoints: (builder) => ({
+    getUserBusinessCards: builder.query<string[], string>({
+      async queryFn(userId) {
+        try {
+          // Supabase 쿼리 실행
+          const { data, error } = await supabase
+            .from('business_cards')
+            .select('business_card_id')
+            .eq('nickname', userId); // nickname이 userId와 매칭되는 데이터 조회
+
+          if (error) {
+            return { error: error.message };
+          }
+
+          // business_card_id 배열 반환
+          return { data: data.map((card) => card.business_card_id) };
+        } catch (err) {
+          return { error: (err as Error).message };
+        }
+      },
+      providesTags: (result) =>
+        result
+          ? result.map((id) => ({ type: 'userCardList', id }))
+          : [{ type: 'userCardList', id: 'LIST' }],
+    }),
+  }),
+});
+
+export const { useGetUserBusinessCardsQuery } = userCardListApi;

--- a/src/pages/CardPreviewPage/CardPreviewPage.tsx
+++ b/src/pages/CardPreviewPage/CardPreviewPage.tsx
@@ -21,7 +21,7 @@ const CardPreviewPage = (): React.JSX.Element => {
   return (
     <div className="flex flex-col items-center gap-4 p-6">
       <h1 className="text-lg font-bold mb-2">명함이 생성되었습니다!</h1>
-      <Card isGlossy={true} isMobile={isMobileDevice} isChat={false} cardColor="#1E90ff" />
+      <Card isGlossy={true} isMobile={isMobileDevice} cardColor="#1E90ff" />
 
       <Button variant="default" className="w-full py-3 rounded-lg mt-5">
         완료

--- a/src/pages/SelectCardDesignPage/SelectCardDesignPage.tsx
+++ b/src/pages/SelectCardDesignPage/SelectCardDesignPage.tsx
@@ -47,7 +47,7 @@ const SelectCardDesignPage = (): React.JSX.Element => {
   return (
     <div className="flex flex-col items-center gap-4 p-6">
       {/* Card 컴포넌트 */}
-      <Card isGlossy={true} isMobile={isMobileDevice} isChat={false} cardColor={cardColor} />
+      <Card isGlossy={true} isMobile={isMobileDevice} cardColor={cardColor} />
       <div className="flex justify-center items-center h-full text-white font-bold">
         카드 디자인
       </div>

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -1,7 +1,90 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { Carousel, CarouselContent, CarouselItem, CarouselApi } from '@components/ui/carousel';
+import { Button } from '@components/ui/button';
+import Card from '@components/commons/Card/Card';
+import { Icon } from '@iconify/react'; // Iconify 아이콘 컴포넌트
 
 const UserPage = (): React.JSX.Element => {
-  return <div></div>;
+  const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
+
+  // 현재 선택된 슬라이드 업데이트
+  useEffect(() => {
+    if (!carouselApi) return;
+
+    const onSelect = () => {
+      setSelectedIndex(carouselApi.selectedScrollSnap());
+    };
+
+    setScrollSnaps(carouselApi.scrollSnapList());
+    carouselApi.on('select', onSelect);
+
+    return () => {
+      carouselApi.off('select', onSelect);
+    };
+  }, [carouselApi]);
+
+  return (
+    <div className="flex flex-col justify-center items-center h-screen">
+      <div className="relative w-[300px] h-[400px]">
+        {/* Carousel */}
+        <Carousel
+          className="w-full h-full"
+          opts={{
+            loop: false, // 단방향으로 설정
+            align: 'center',
+          }}
+          setApi={setCarouselApi}
+        >
+          <CarouselContent>
+            {/* 첫 번째 카드 */}
+            <CarouselItem>
+              <Card isGlossy={true} isMobile={false} isInteractive={false} cardColor="#1E90FF" />
+            </CarouselItem>
+
+            {/* 두 번째 카드 */}
+            <CarouselItem>
+              <Card isGlossy={true} isMobile={false} isInteractive={false} cardColor="#FF6347" />
+            </CarouselItem>
+
+            {/* 세 번째 카드 */}
+            <CarouselItem>
+              <Card isGlossy={true} isMobile={false} isInteractive={false} cardColor="#32CD32" />
+            </CarouselItem>
+
+            {/* 추가 버튼 카드 */}
+            <CarouselItem>
+              <Button
+                variant="outline"
+                className="w-full h-full border-dashed border-2 border-gray-400 rounded-md flex items-center justify-center"
+              >
+                <span className="text-gray-400 text-5xl font-bold">+</span>
+              </Button>
+            </CarouselItem>
+          </CarouselContent>
+        </Carousel>
+      </div>
+
+      {/* Indicators */}
+      <div className="flex gap-2 mt-25">
+        {scrollSnaps.map((_, index) => (
+          <button
+            key={index}
+            onClick={() => carouselApi?.scrollTo(index)} // 해당 슬라이드로 이동
+            className={`w-3 h-3 rounded-full transition-colors flex items-center justify-center ${
+              selectedIndex === index ? 'bg-blue-500' : 'bg-gray-300'
+            }`}
+          >
+            {/* 추가 버튼 카드의 인디케이터에만 Iconify plus 아이콘 표시 */}
+            {index === scrollSnaps.length - 1 ? (
+              <Icon icon="mdi:plus" className="text-white text-xs" />
+            ) : null}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
 };
 
 export default UserPage;

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -6,6 +6,8 @@ import Card from '@components/commons/Card/Card';
 import { Icon } from '@iconify/react'; // Iconify 아이콘 컴포넌트
 import { useGetUserBusinessCardsQuery } from '@features/UserPage/api/userCardListApi';
 
+const MAX_CARDS = 3;
+
 const UserPage = (): React.JSX.Element => {
   const { userId } = useParams<{ userId: string }>();
   const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null);
@@ -39,6 +41,8 @@ const UserPage = (): React.JSX.Element => {
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p>Error fetching card IDs</p>;
 
+  const showAddButton = cardIds!.length < MAX_CARDS;
+
   return (
     <div className="flex flex-col justify-center items-center h-screen">
       <div className="relative w-[300px] h-[400px]">
@@ -66,35 +70,40 @@ const UserPage = (): React.JSX.Element => {
               </CarouselItem>
             ))}
 
-            {/* 추가 버튼 카드 */}
-            <CarouselItem>
-              <Button
-                variant="outline"
-                className="w-full h-full border-dashed border-2 border-gray-400 rounded-md flex items-center justify-center"
-              >
-                <span className="text-gray-400 text-5xl font-bold">+</span>
-              </Button>
-            </CarouselItem>
+            {/* 추가 버튼 카드 (카드 개수가 MAX_CARDS보다 적을 때만 표시) */}
+            {showAddButton && (
+              <CarouselItem>
+                <Button
+                  variant="outline"
+                  className="w-full h-full border-dashed border-2 border-gray-400 rounded-md flex items-center justify-center"
+                >
+                  <span className="text-gray-400 text-5xl font-bold">+</span>
+                </Button>
+              </CarouselItem>
+            )}
           </CarouselContent>
         </Carousel>
       </div>
 
       {/* Indicators */}
       <div className="flex gap-2 mt-25">
-        {scrollSnaps.map((_, index) => (
-          <button
-            key={index}
-            onClick={() => carouselApi?.scrollTo(index)} // 해당 슬라이드로 이동
-            className={`w-3 h-3 rounded-full transition-colors flex items-center justify-center ${
-              selectedIndex === index ? 'bg-blue-500' : 'bg-gray-300'
-            }`}
-          >
-            {/* 추가 버튼 카드의 인디케이터에만 Iconify plus 아이콘 표시 */}
-            {index === scrollSnaps.length - 1 ? (
-              <Icon icon="mdi:plus" className="text-white text-xs" />
-            ) : null}
-          </button>
-        ))}
+        {scrollSnaps.map(
+          (_, index) =>
+            index < cardIds!.length + (showAddButton ? 1 : 0) && ( // 인디케이터 개수 제한
+              <button
+                key={index}
+                onClick={() => carouselApi?.scrollTo(index)} // 해당 슬라이드로 이동
+                className={`w-3 h-3 rounded-full transition-colors flex items-center justify-center ${
+                  selectedIndex === index ? 'bg-blue-500' : 'bg-gray-300'
+                }`}
+              >
+                {/* 추가 버튼 카드의 인디케이터에만 Iconify plus 아이콘 표시 */}
+                {showAddButton && index === scrollSnaps.length - 1 ? (
+                  <Icon icon="mdi:plus" className="text-white text-xs" />
+                ) : null}
+              </button>
+            ),
+        )}
       </div>
     </div>
   );

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -82,7 +82,8 @@ const UserPage = (): React.JSX.Element => {
                   isInteractive={false}
                   cardId={cardIds[index]}
                   nickname={userId}
-                  cardColor={index % 2 === 0 ? '#1E90FF' : '#FF6347'} // 색상은 임의로 설정
+                  cardColor={index % 2 === 0 ? '#1E90FF' : '#FF6347'}
+                  refetch={refetch}
                 />
               </CarouselItem>
             ))}

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -59,6 +59,8 @@ const UserPage = (): React.JSX.Element => {
                   isGlossy={true}
                   isMobile={false}
                   isInteractive={false}
+                  cardId={cardIds[index]}
+                  nickname={userId}
                   cardColor={index % 2 === 0 ? '#1E90FF' : '#FF6347'} // 색상은 임의로 설정
                 />
               </CarouselItem>

--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -1,13 +1,18 @@
 import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { Carousel, CarouselContent, CarouselItem, CarouselApi } from '@components/ui/carousel';
 import { Button } from '@components/ui/button';
 import Card from '@components/commons/Card/Card';
 import { Icon } from '@iconify/react'; // Iconify 아이콘 컴포넌트
+import { useGetUserBusinessCardsQuery } from '@features/UserPage/api/userCardListApi';
 
 const UserPage = (): React.JSX.Element => {
+  const { userId } = useParams<{ userId: string }>();
   const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
+
+  const { data: cardIds, isLoading, error } = useGetUserBusinessCardsQuery(userId || '');
 
   // 현재 선택된 슬라이드 업데이트
   useEffect(() => {
@@ -25,6 +30,15 @@ const UserPage = (): React.JSX.Element => {
     };
   }, [carouselApi]);
 
+  useEffect(() => {
+    if (cardIds) {
+      console.log('Fetched card IDs:', cardIds[0]);
+    }
+  }, [cardIds]);
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error fetching card IDs</p>;
+
   return (
     <div className="flex flex-col justify-center items-center h-screen">
       <div className="relative w-[300px] h-[400px]">
@@ -38,20 +52,17 @@ const UserPage = (): React.JSX.Element => {
           setApi={setCarouselApi}
         >
           <CarouselContent>
-            {/* 첫 번째 카드 */}
-            <CarouselItem>
-              <Card isGlossy={true} isMobile={false} isInteractive={false} cardColor="#1E90FF" />
-            </CarouselItem>
-
-            {/* 두 번째 카드 */}
-            <CarouselItem>
-              <Card isGlossy={true} isMobile={false} isInteractive={false} cardColor="#FF6347" />
-            </CarouselItem>
-
-            {/* 세 번째 카드 */}
-            <CarouselItem>
-              <Card isGlossy={true} isMobile={false} isInteractive={false} cardColor="#32CD32" />
-            </CarouselItem>
+            {/* 조회한 명함 개수만큼 Card 컴포넌트 렌더링 */}
+            {cardIds?.map((cardId, index) => (
+              <CarouselItem key={cardId}>
+                <Card
+                  isGlossy={true}
+                  isMobile={false}
+                  isInteractive={false}
+                  cardColor={index % 2 === 0 ? '#1E90FF' : '#FF6347'} // 색상은 임의로 설정
+                />
+              </CarouselItem>
+            ))}
 
             {/* 추가 버튼 카드 */}
             <CarouselItem>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -19,7 +19,7 @@ import RealCardScanPage from '@pages/RealCardScanPage/RealCardScanPage';
 import UserInterestsPage from '@pages/UserInterestsPage/UserInterestsPage';
 import CardPreviewPage from '@pages/CardPreviewPage/CardPreviewPage';
 import QrScannerPage from '@pages/QrScannerPage/QrScannerPage';
-import BusinessCardBookPage from '@pages/BusinessCardBookPage/UserPage';
+import BusinessCardBookPage from '@pages/BusinessCardBookPage/BusinessCardBookPage';
 
 const AppRouter = () => {
   return (
@@ -29,7 +29,7 @@ const AppRouter = () => {
       <Route path={RoutePaths.SIGNUP} element={<SignupPage />} />
       <Route path={RoutePaths.SELECTCARDDESIGN} element={<SelectCardDesignPage />} />
       <Route path={RoutePaths.ADDITIONALINFO} element={<AdditionalInfoPage />} />
-      <Route path={RoutePaths.USER} element={<UserPage />} />
+      <Route path={`${RoutePaths.USER}/:userId?`} element={<UserPage />} />
       <Route path={`${RoutePaths.USER}${RoutePaths.CARD}/:cardId?`} element={<UserCardPage />} />
       <Route path={`${RoutePaths.USER}${RoutePaths.SETTING}`} element={<UserSettingPage />} />
       <Route path={RoutePaths.INFO} element={<InfoPage />} />

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,11 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { userCardListApi } from '@features/UserPage/api/userCardListApi';
+import { businessCardApi } from '@features/BusinessCard/api/businessCardApi';
 
 const store = configureStore({
   reducer: {
     [userCardListApi.reducerPath]: userCardListApi.reducer,
+    [businessCardApi.reducerPath]: businessCardApi.reducer,
   },
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(userCardListApi.middleware), // API 미들웨어 추가
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: false,
+    }).concat(userCardListApi.middleware, businessCardApi.middleware),
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,10 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
-import counterReducer from '@store/slices/counterSlice';
+import { userCardListApi } from '@features/UserPage/api/userCardListApi';
 
 const store = configureStore({
   reducer: {
-    counter: counterReducer,
+    [userCardListApi.reducerPath]: userCardListApi.reducer,
   },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(userCardListApi.middleware), // API 미들웨어 추가
 });
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
 
 export default store;


### PR DESCRIPTION
## 연관 이슈
- #50 

## 작업 요약
- 명함 리스트 및 명함 기능 구현

## 작업 상세 설명
- 유저 페이지
  - 유저의 명함 리스트 조회 API 구현
    - 고려해야 할 점: 명함 순서 & 정렬 기능 필요 여부 
  - 명함 추가 API 구현
    - 3개까지 추가 가능 
  - 명함 삭제 API 구현
    - 대표 명함은 삭제 불가능
- 명함
  - 명함 정보 조회 API 구현
  - 대표 명함 설정 API 구현
    - 대표 명함은 한 유저당 1개
    - 대표 명함은 삭제 불가능

## 추가되는 dependencies
- embla-carousel-react
  - Shadcn UI Carousel을 이용하기 위한 캐러셀 라이브러리

## 리뷰 요구사항
- 리뷰 예상 시간: 10분
- 보완해야 할 점
  - userSlice 추가 후 본인만 접근 가능하도록
  - 공유 바텀시트 추가

## Preview 이미지 (필요시)
![image](https://github.com/user-attachments/assets/89f984e2-b66f-4f9b-87cb-ed520446fc6c)

