### PR TITLE
글로벌 폰트 적용

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto&family=Nanum+Gothic&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Nanum+Gothic&family=Roboto&display=swap');
+
 @import 'tailwindcss';
 @plugin "tailwindcss-animate";
 
@@ -10,6 +13,9 @@ body {
 }
 /* custom color */
 @theme {
+  /* font */
+  --font-sans: 'Roboto', 'Nanum Gothic', sans-serif;
+
   /* bg */
   --bg-default-black: #121212;
 


### PR DESCRIPTION
## 연관 이슈
> #154 

## 작업 요약
> 글로벌 폰트 적용

## 작업 상세 설명
- `@import`로 Google Fonts의 Roboto와 Nanum Gothic 불러옴
- `@theme` 내에 `--font-sans` CSS 변수를 정의하고, Tailwind `font-sans`에 적용
- 기본 텍스트는 `font-sans`로 통일 적용, 한글과 영어가 자동 분기되도록 fallback 구조 설정
- UI 테스트

## 리뷰 요구사항
> 페이지 전체에서 폰트 적용이 잘 fallback되고 있는지 테스트 (특히 한글/영문 혼합 케이스)


## Preview 이미지 (필요시)
